### PR TITLE
A few upgrades and minor fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,3 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.yml]
-indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.1'
 
             - name: Check PHP Version
               run: php -v
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['8.0', '8.1', '8.2']
+                php-versions: ['8.1', '8.2']
 
         steps:
             - name: Checkout code
@@ -61,7 +61,7 @@ jobs:
             - name: Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.1'
 
             - name: Check PHP Version
               run: php -v

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,9 +10,8 @@ $config = new Config();
 
 return $config->setFinder($finder)
     ->setRules([
-        '@PSR12' => true,
+        '@PER-CS' => true,
         'strict_param' => true,
-        'single_class_element_per_statement' => false,
+        'array_syntax' => ['syntax' => 'short'],
     ])
-    ->setRiskyAllowed(true)
-    ->setUsingCache(true);
+    ->setRiskyAllowed(true);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ guarantee that your feature will be merged.
 ### Coding Style
 
 This package follows the
-[PSR-12](https://www.php-fig.org/psr/psr-12/) coding standard.
+[PER Coding Style](https://www.php-fig.org/per/coding-style/).
 You can run PHP CS Fixer via `composer cs` for a dry run or
 `composer cs-fix` to automatically fix code style issues.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Christian Olear
+Copyright (c) 2023 Christian Olear
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
         }
     },
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
-        "pestphp/pest": "^1.22",
-        "phpstan/phpstan": "^1.8",
-        "friendsofphp/php-cs-fixer": "^3.11"
+        "pestphp/pest": "^2.19",
+        "phpstan/phpstan": "^1.10",
+        "friendsofphp/php-cs-fixer": "^3.30"
     },
     "scripts": {
         "test": "@php vendor/bin/pest",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,5 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"
+#    ignoreErrors:
+#        - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./app</directory>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+         cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage/>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
* Upgrade from PSR-12 conding style to PER.
* Upgrade PEST to v2.
* Set min PHP version to 8.1. Support for 8.0 ends in November, so newly created packages don't need to support 8.0 anymore. Also the main crawler package already has 8.1 as min requirement.
* Update year in LICENSE file.
* Auto-upgrade phpunit.xml.
* Remove .yml indent size in .editorconfig as the github ci.yml actually uses 4 which is the editorconfig default for all files.