### PR TITLE
Enable PEST ^4.0 for PHP 8.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,17 @@
             "Crwlr\\PackageTemplate\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": "^8.1"
     },
     "require-dev": {
-        "pestphp/pest": "^2.19|^3.0",
-        "phpstan/phpstan": "^1.10",
+        "pestphp/pest": "^2.0|^3.0|^4.0",
+        "phpstan/phpstan": "^1.10|^2.0",
         "friendsofphp/php-cs-fixer": "^3.57"
     },
     "scripts": {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use Crwlr\PackageTemplate\ExampleClass;
 
 test('method foo returns bar', function () {


### PR DESCRIPTION
Further, also introduce Tests namespace in tests dir and enable PHPStan ^2.0.